### PR TITLE
README: fix examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,8 @@ npm install -g jsondepth
 
 real world example:
 ```sh
-url=https://www.wikidata.org/w/api.php?action=wbgetentities&ids=Q1&format=json
-curl -s $url | jsondepth
+url='https://www.wikidata.org/w/api.php?action=wbgetentities&ids=Q1&format=json'
+curl -s "$url" | jsondepth
 ```
 logs the object with only the first-level keys and values:
 ```js
@@ -30,18 +30,18 @@ for the sake of convenience and lazyness, **jsondepth is aliased to jd**
 <br>
 (which, purposedly make it look a bit like jq)
 ```
-curl -s $url | jd
+curl -s "$url" | jd
 ```
 
 ###Specify a depth level
 this is equivalent to the two previous one:
 ```
-curl -s $url | jd 0
+curl -s "$url" | jd 0
 ```
 <hr>
 now let's go one-level deeper:
 ```
-curl -s $url | jd 1
+curl -s "$url" | jd 1
 ```
 outputs:
 ```js
@@ -50,41 +50,41 @@ outputs:
 <hr>
 ![we need to go deeper](http://vignette3.wikia.nocookie.net/glee/images/6/6f/We-need-to-go-deeper_inception.jpg/revision/latest)
 ```sh
-curl -s $url | jd 2
-curl -s $url | jd 3
-curl -s $url | jd 4
+curl -s "$url" | jd 2
+curl -s "$url" | jd 3
+curl -s "$url" | jd 4
 # etc
 ```
 <hr>
 If you use [paths](#specify-a-path), you may wish to disable object wrapping: this can be done by passing `-1`. The advantage is that you are sure to get back a valid json object.
 ```sh
-curl -s $url | jd -1
+curl -s "$url" | jd -1
 ```
 
 ###Specify a path
 ```sh
-curl -s $url | jd entities.Q1.aliases.fi.1
+curl -s "$url" | jd entities.Q1.aliases.fi.1
 # or to mimick jq syntax
-curl -s $url | jd .entities.Q1.aliases.fi.1
+curl -s "$url" | jd .entities.Q1.aliases.fi.1
 ```
 
 ###Specify a depth and a path
 if both a path and a depth are specified, **path should come first, depth second**
 ```sh
-curl -s $url | jd entities.Q1.claims.P31.0 3
+curl -s "$url" | jd entities.Q1.claims.P31.0 3
 ```
 
 ###Access JS objects attributes
 ####Native attributes
 #####Arrays `length`
 ```sh
-curl -s $url | jd entities.Q1.aliases.en.length
+curl -s "$url" | jd entities.Q1.aliases.en.length
 # => 5
 ```
 ####Special keys
 #####`_keys`
 apply `Object.keys` to the final object
 ```sh
-curl -s $url | jd entities._keys
+curl -s "$url" | jd entities._keys
 # => ['Q1']
 ```


### PR DESCRIPTION
The example URL contains '&' which has a special meaning in the shell, so it must be escaped.
